### PR TITLE
Adding a safe check for Piwik Url

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function PiwikTracker(siteId, trackerUrl) {
   }
 
   if (trackerUrl.toString().indexOf("piwik.php")== -1){
-    throw new Error('A tracker URL must be provided, e.g. http://example.com/piwik.php');
+    throw new Error('A tracker URL must contain piwik.php in the URL, e.g. http://example.com/piwik.php');
   }
 
   this.siteId = siteId;

--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ function PiwikTracker(siteId, trackerUrl) {
     throw new Error('A tracker URL must be provided, e.g. http://example.com/piwik.php');
   }
 
+  if (trackerUrl.toString().indexOf("piwik.php")== -1){
+    throw new Error('A tracker URL must be provided, e.g. http://example.com/piwik.php');
+  }
+
   this.siteId = siteId;
   this.trackerUrl = trackerUrl;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,6 +27,10 @@ describe('PiwikTracker()', function() {
     (function(){ new PiwikTracker(1); }).should.throw(/tracker/);
   });
 
+  it('should thow if no trackerUrl is not valid (no piwik.php endpoint)', function() {
+    (function(){ new PiwikTracker(1,'http://example.com/index.php'); }).should.throw(/tracker/);
+  });
+
   it('should have properties siteId/trackerUrl', function() {
     var piwik = new PiwikTracker(1, 'http://example.com/piwik.php');
     piwik.siteId.should.equal(1);


### PR DESCRIPTION
Hi, I was using the API and by mistake I was using /index.php rather than /piwik.php, there was not errors but I was not able to track the traffic.
After a while, I found out that I was using the wrong URL endpoing (e.g without the piwik.php).

This Pull Request adds a new validation to the URL to help troubleshoot any issue.