### PR TITLE
Add support for string type site IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function PiwikTracker (siteId, trackerUrl) {
   if (!(this instanceof PiwikTracker)) { return new PiwikTracker(siteId, trackerUrl); }
   events.EventEmitter.call(this);
 
-  assert.ok(siteId && !isNaN(siteId), 'Piwik siteId required.');
+  assert.ok(siteId && (typeof siteId == 'number' || typeof siteId == 'string'), 'Piwik siteId required.');
   assert.ok(trackerUrl && typeof trackerUrl == 'string', 'Piwik tracker URL required, e.g. http://example.com/piwik.php')
   assert.ok(trackerUrl.endsWith('piwik.php'), 'A tracker URL must end with "piwik.php"')
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,19 +15,26 @@ chai.use(sinonChai);
 var PiwikTracker = require('../index.js');
 describe('PiwikTracker()', () => {
 
-  it('should thow if no parameters provided', () => {
+  it('should throw if no parameters provided', () => {
     (() => new PiwikTracker()).should.throw(/siteId/);
   });
 
-  it('should thow if no siteId is provided', () => {
+  it('should throw if no siteId is provided', () => {
     (() => new PiwikTracker(null)).should.throw(/siteId/);
   });
+    
+  it('should throw if siteId provided is neither a number nor a string', () => {
+    (() => new PiwikTracker({ foo: 'bar' })).should.throw(/siteId/);
+    (() => new PiwikTracker([1,2,3])).should.throw(/siteId/);
+    (() => new PiwikTracker(true)).should.throw(/siteId/);
+    (() => new PiwikTracker(() => { return true; })).should.throw(/siteId/);
+  }); 
 
-  it('should thow if no trackerUrl is provided', () => {
+  it('should throw if no trackerUrl is provided', () => {
     (() => new PiwikTracker(1)).should.throw(/tracker/);
   });
 
-  it('should thow if no trackerUrl is not valid (no piwik.php endpoint)', () => {
+  it('should throw if no trackerUrl is not valid (no piwik.php endpoint)', () => {
     (() => new PiwikTracker(1,'http://example.com/index.php')).should.throw(/tracker/);
   });
 


### PR DESCRIPTION
There is a plugin on the Piwik marketplace that allows using site URLs as site IDs in addition to numbers:

[https://plugins.piwik.org/SiteUrlTrackingID](https://plugins.piwik.org/SiteUrlTrackingID)

I'm using this in a project where PIwik is being used for various white-labeled instances of a common site for centralized analytics. Unfortunately, the current version of piwik-tracker requires numerical site IDs only, and so is incompatible with this plugin.

This pull request changes the strict numerical type checking on site ID during initialization to still be strict but allow numbers or strings. I expanded the test suite to make sure truthy values of other types (boolean, object, function, etc.) continue to throw the exception as expected.